### PR TITLE
リダイレクト処理の修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,11 +1,9 @@
-const videoPlayer = document.querySelector('video');
+let videoPlayer = document.querySelector('video');
 
 window.addEventListener('load', function() {
-
   chrome.storage.local.get(['isClipMode', 'clipStartTime', 'clipEndTime'], function(result) {
     if (result.isClipMode === undefined) { result.isClipMode = false }
 
-    // isClipMode = result.isClipMode;
     if (result.isClipMode) {
       clipStartTime = result.clipStartTime;
       clipEndTime = result.clipEndTime;
@@ -254,6 +252,7 @@ function observeVideoElement() {
     // 動画が再生中である場合のみ処理を実行
     if (!observedVideoPlayer.paused) {
       observedVideoPlayer.addEventListener('loadeddata', function() {
+        if (videoPlayer === null) { videoPlayer = document.querySelector('video') };
         resetFilters();
         applyFilters();
         resetPlayerReverse();

--- a/content.js
+++ b/content.js
@@ -2,42 +2,24 @@ const videoPlayer = document.querySelector('video');
 
 window.addEventListener('load', function() {
 
-  //埋め込みURLにアクセスした場合、擬似クリップにリダイレクト
-  const url = new URL(window.location.href);
-  if (isEmbedURL(url.href)) {
-    isClipMode = "true";
-    const urlObject = new URL(url.href);
-    const urlParams = new URLSearchParams(urlObject.search);
-    const videoID = urlObject.pathname.split('/').pop();
-    let clipModeStart = parseFloat(urlParams.get('start'));
-    let clipModeEnd = parseFloat(urlParams.get('end'));
-    localStorage.setItem('isClipMode', JSON.stringify(isClipMode));
-    localStorage.setItem('clipModeStart', JSON.stringify(clipModeStart));
-    localStorage.setItem('clipModeEnd', JSON.stringify(clipModeEnd));
-    window.location.href = "https://www.youtube.com/watch?v=" + videoID;
-    return
-  }
+  chrome.storage.local.get(['isClipMode', 'clipStartTime', 'clipEndTime'], function(result) {
+    if (result.isClipMode === undefined) { result.isClipMode = false }
 
-  isClipMode = JSON.parse(localStorage.getItem('isClipMode'));
-  if (isClipMode) {
-    clipStartTime = JSON.parse(localStorage.getItem('clipModeStart'));
-    clipEndTime = JSON.parse(localStorage.getItem('clipModeEnd'));
-    setClipVideo("clip")
-    localStorage.setItem('isClipMode', JSON.stringify(!isClipMode));
-  }
+    // isClipMode = result.isClipMode;
+    if (result.isClipMode) {
+      clipStartTime = result.clipStartTime;
+      clipEndTime = result.clipEndTime;
+      setClipVideo("clip");
+      chrome.storage.local.set({ clipModeStart: 0 });
+      chrome.storage.local.set({ clipModeEnd: 60 });
+      chrome.storage.local.set({ isClipMode: false });
+    }
+  });
 
   //拡張機能を入れると同時に、上部の影は一切表示されなくなります。
   const shadowTop = document.querySelector('.ytp-gradient-top');
   if (shadowTop) {
     shadowTop.style.display = 'none';
-  }
-});
-
-window.addEventListener('beforeunload', (event) => {
-  const url = new URL(window.location.href);
-  if (!isEmbedURL(url.href)) {
-    isClipMode = false;
-    localStorage.setItem('isClipMode', JSON.stringify(false));
   }
 });
 
@@ -394,7 +376,6 @@ function setClipVideo(request) {
     resetClipVideo();
     resetClipVideoTime();
     isClipMode = false;
-    localStorage.setItem('isClipMode', JSON.stringify(false));
   }
 }
 

--- a/content_LocalTube.js
+++ b/content_LocalTube.js
@@ -1,0 +1,18 @@
+window.addEventListener('load', function() {
+  const currentPath = window.location.pathname;
+
+  if (currentPath === '/clip_redirect') {
+    const url = new URLSearchParams(window.location.search);
+    const videoID = url.get('videoID');
+    const startTime = url.get('start');
+    const endTime = url.get('end');
+
+    chrome.storage.local.set({ clipStartTime: startTime });
+    chrome.storage.local.set({ clipEndTime: endTime });
+    chrome.storage.local.set({ isClipMode: true });
+
+    setTimeout(function() {
+      window.location.href = "https://www.youtube.com/watch?v=" + videoID;
+    },1000);
+  }
+});

--- a/content_LocalTube.js
+++ b/content_LocalTube.js
@@ -13,6 +13,6 @@ window.addEventListener('load', function() {
 
     setTimeout(function() {
       window.location.href = "https://www.youtube.com/watch?v=" + videoID;
-    },1000);
+    },100);
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   },
   "name": "YouTube動画拡張",
   "version": "1.0",
-  "permissions": ["scripting", "activeTab"],
+  "permissions": ["scripting", "activeTab", "storage"],
   "action": {
     "default_popup": "popup.html"
   },
@@ -15,6 +15,10 @@
     {
       "matches": ["*://*.youtube.com/*"],
       "js": ["content.js"]
+    },
+    {
+      "matches": ["http://localhost:6789/*"],
+      "js": ["content_LocalTube.js"]
     }
   ]
 }


### PR DESCRIPTION
# What
「embedリンクからのリダイレクト」から「localhost:6789/clip_redirectからのリダイレクト」に変更

# Why
embedからリダイレクトすると、ユーザーエクスペリエンスを損なうため、変更となった。具体的には画面がカクカクする、動画によっては、アクセス禁止ページが表示されてしまうなど

# 具体的な処理内容
外部システムから/clip_redirectへアクセスした際、content_LocalTube.jsのloadでリダイレクトする方針に変更。リダイレクトする際、chrome.storage.localへパラメータを保存する。
