### PR TITLE
一部設定修正

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "128": "icon-128.png"
   },
   "name": "YouTube動画拡張",
-  "version": "1.0",
+  "version": "1.1",
   "permissions": ["scripting", "activeTab", "storage"],
   "action": {
     "default_popup": "popup.html"
@@ -17,7 +17,7 @@
       "js": ["content.js"]
     },
     {
-      "matches": ["http://localhost:6789/clip_redirect*"],
+      "matches": ["http://localhost:50000/clip_redirect*"],
       "js": ["content_LocalTube.js"]
     }
   ]

--- a/popup.html
+++ b/popup.html
@@ -10,12 +10,12 @@
       <input type="submit" id="resetButton" class="" value="リセット">
     </form>
     <form action="#">
-      <input type="submit" id="clipOpenButton" class="" value="クリップ設定を表示">
+      <input type="submit" id="clipOpenButton" class="" value="擬似クリップ設定を表示">
     </form>
     <div id="clipSettings" class="hidden">
       <form action="#">
-        <input type="text" id="clipName" placeholder="クリップ名を記入">
-        <input type="submit" id="clipSaveButton" class="" value="保存(localserver連携)" disabled>
+        <input type="text" id="clipName" placeholder="擬似クリップ名を記入">
+        <input type="submit" id="clipSaveButton" class="" value="保存(擬似クリップ)">
       </form>
       <form action="#">
         <label for="startTime" id="startTimeLabel">開始時刻 hh:mm:ss:ms</label>
@@ -32,10 +32,10 @@
           <input type="number" id="endTimeSs" placeholder="ss" value="0" min="0" max="59" step="1"> :
           <input type="number" id="endTimeMs" placeholder="ms" value="0" min="0" max="999" step="100">
         </div>
-        <input type="submit" id="clipApplyButton" class="" value="クリップ適応">
+        <input type="submit" id="clipApplyButton" class="" value="擬似クリップ適応">
       </form>
       <form action="#">
-        <input type="submit" id="clipResetButton" class="" value="クリップ解除" disabled>
+        <input type="submit" id="clipResetButton" class="" value="擬似クリップ解除" disabled>
       </form>
     </div>
     <form action="#">

--- a/popup.js
+++ b/popup.js
@@ -111,10 +111,10 @@ clipOpenButton.addEventListener("click", (event) =>{
   event.preventDefault();
 
   if (isOpenClip) {
-    clipOpenButton.value = "クリップ設定を表示"
+    clipOpenButton.value = "擬似クリップ設定を表示"
     clipSettings.style.display = "none";
   } else {
-    clipOpenButton.value = "クリップ設定を閉じる"
+    clipOpenButton.value = "擬似クリップ設定を閉じる"
     clipSettings.style.display = "block";
   }
   isOpenClip = !isOpenClip
@@ -504,15 +504,11 @@ function url2videoID(url){
 }
 
 function buttonEnable() {
-  clipSaveButton.disabled = false;
-  clipSaveButton.classList.remove("disabled");
   clipResetButton.disabled = false;
   clipResetButton.classList.remove("disabled");
 }
 
 function buttonDisabled() {
-  clipSaveButton.disabled = true;
-  clipSaveButton.classList.add("disabled");
   clipResetButton.disabled = true;
   clipResetButton.classList.add("disabled");
 }

--- a/popup.js
+++ b/popup.js
@@ -169,7 +169,8 @@ clipSaveButton.addEventListener("click", (event) => {
             formData.append("end_time", endTime);
             formData.append("image", blob, "image.png");
 
-            fetch("http://localhost:6789/images", {
+            const port = 50000;
+            fetch(`http://localhost:${port}/images`, {
               method: "POST",
               body: formData,
               }


### PR DESCRIPTION
# What
- ポート番号の変更(カスタムポート)
- クリップを擬似クリップに名称を変更
- 擬似クリップ保存ボタンの制御撤廃

# Why
- ユーザーのPCによってはすでにそのポート番号が予約済みである可能性があったため
- 先日、名称が変更となったため
- 制御する必要がなくなったため(動画全体をそのまま保存したい人がいるとの意見)